### PR TITLE
Feat: Configurable label/decoration styles + "sane"-er defaults for light themes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,85 @@
 					"type": "boolean",
 					"default": true,
 					"description": "When enabled, lines that do not contain any words will include a jump point at the end of the line"
+				},
+				"vscode-easymotion.styles": {
+					"type": "object",
+					"title": "Decoration Styles",
+					"description": "Styles to apply to the jump points' labels. To set styles per color mode, use the 'dark' and 'light' properties. To set styles irrespective of color mode, use the unnested properties directly.",
+					"properties": {
+						"borderColor": { 
+							"type": "string", 
+							"default": "#cccccc" 
+						},
+						"fontWeight": { 
+							"type": "string", 
+							"default": "bold", 
+							"enum": ["bold", "normal", "100", "200", "300", "400", "500", "600", "700", "800", "900"]},
+						"colors": {
+							"title": "Jump point label colors", 
+							"description": "Colors to paint each jump point's label with. Each color in the array will be iterated through as the labels get longer.", 
+							"type": "array", 
+							"default": ["#ff5555", "yellow", "lime", "magenta"], 
+							"items": {
+								"type": "string"}
+							},
+						"width": {
+							"type": "string", 
+							"default": "0px"
+						},
+						"dark": {
+							"type": "object",
+							"title": "Decoration Styles for Dark Themes",
+							"properties": {
+								"borderColor": { 
+									"type": "string", 
+									"default": "#cccccc" 
+								},
+								"fontWeight": { 
+									"type": "string", 
+									"default": "bold", 
+									"enum": ["bold", "normal", "100", "200", "300", "400", "500", "600", "700", "800", "900"]},
+								"colors": {
+									"title": "Jump point label colors", 
+									"description": "Colors to paint each jump point's label with. Each color in the array will be iterated through as the labels get longer.", 
+									"type": "array", 
+									"default": ["#ff5555", "yellow", "lime", "magenta"], 
+									"items": {
+										"type": "string"}
+									},
+								"width": {
+									"type": "string", 
+									"default": "0px"
+								}
+							}
+						},
+						"light": {
+							"type": "object",
+							"title": "Decoration Styles for Light Themes",
+							"properties": {
+								"borderColor": { 
+									"type": "string", 
+									"default": "#cccccc" 
+								},
+								"fontWeight": { 
+									"type": "string", 
+									"default": "bold", 
+									"enum": ["bold", "normal", "100", "200", "300", "400", "500", "600", "700", "800", "900"]},
+								"colors": {
+									"title": "Jump point label colors", 
+									"description": "Colors to paint each jump point's label with. Each color in the array will be iterated through as the labels get longer.", 
+									"type": "array", 
+									"default": ["#ff5555", "#323D00", "#190096", "#750042"], 
+									"items": {
+										"type": "string"}
+									},
+								"width": {
+									"type": "string", 
+									"default": "0px"
+								}
+							}
+						}
+					}
 				}
 			}
 		}

--- a/src/command.ts
+++ b/src/command.ts
@@ -289,7 +289,12 @@ function decoratePositions(config: Configuration, context: ActiveCommandContext,
     if (context.isEnteringFilter) return;
 
     const decorationsArray: vscode.DecorationOptions[] = [];
-    const colors = ['#ff5555', 'yellow', 'lime', 'magenta'];
+    const darkColors = config.Styles?.dark?.colors ?? DEFAULT_STYLES.dark.colors;
+    const lightColors = config.Styles?.light?.colors ?? DEFAULT_STYLES.light.colors;
+
+    const colorKind = vscode.window.activeColorTheme.kind;
+    const colors = (colorKind === vscode.ColorThemeKind.Light) ? lightColors : darkColors;
+
     for(let i = 0; i < positions.length; i++)
     {
         const pos = positions[i];
@@ -301,7 +306,7 @@ function decoratePositions(config: Configuration, context: ActiveCommandContext,
         // const textToDraw = pos.combo;
         const tgColor = colors[(pos.combo.length - valueToSub) % colors.length];
 
-        const styling = {
+        const baseStyling: vscode.ThemableDecorationAttachmentRenderOptions = {
             border: '0 0 0 2px',
             borderColor: '#cccccc',
             fontWeight: 'bold',
@@ -309,18 +314,28 @@ function decoratePositions(config: Configuration, context: ActiveCommandContext,
             color: tgColor,
             width: '0px'
         };
+        const darkStyling: vscode.ThemableDecorationAttachmentRenderOptions = {
+            ...baseStyling,
+            ...config.Styles?.dark ?? {},
+            color: tgColor
+        };
+        const lightStyling: vscode.ThemableDecorationAttachmentRenderOptions = {
+            ...baseStyling,
+            ...config.Styles?.dark ?? {},
+            color: tgColor
+        };
 
         decorationsArray.push({ range: new vscode.Range(pos.line, pos.offset, pos.line, pos.offset + textToDraw.length),
             renderOptions:
             {
                 dark: 
                 {
-                    before: styling
+                    before: darkStyling
                 },
                 light: 
                 {
-                    before: styling
-                }
+                    before: lightStyling
+                },
             }
         });
     }
@@ -361,16 +376,21 @@ export const DEFAULT_STYLES: StylesConfiguration = {
 
 export class Configuration
 {
-    constructor(unfocused: vscode.TextEditorDecorationType, decoration: vscode.TextEditorDecorationType, allowJumpToWordlessLine: boolean)
+    constructor(unfocused: vscode.TextEditorDecorationType, 
+        decoration: vscode.TextEditorDecorationType, 
+        allowJumpToWordlessLine: boolean,
+        styles: StylesConfiguration)
     {
         this.UnfocusedDecoration = unfocused;
         this.Decoration = decoration;
         this.AllowJumpingToWordlessLine = allowJumpToWordlessLine;
+        this.Styles = styles;
     }
 
     UnfocusedDecoration: vscode.TextEditorDecorationType;
     Decoration: vscode.TextEditorDecorationType;
     AllowJumpingToWordlessLine: boolean;
+    Styles: StylesConfiguration;
 }
 
 export class ActiveCommandContext

--- a/src/command.ts
+++ b/src/command.ts
@@ -329,6 +329,36 @@ function decoratePositions(config: Configuration, context: ActiveCommandContext,
     editor.setDecorations(config.Decoration, decorationsArray);
 }
 
+type DecorationStyles = {
+    colors: string[];
+    borderColor: string;
+    fontWeight: string;
+    width: string;
+};
+
+export type StylesConfiguration = DecorationStyles & {
+    [color in "dark" | "light"]: DecorationStyles;
+};
+
+export const DEFAULT_STYLES: StylesConfiguration = {
+    borderColor: '#cccccc',
+    fontWeight: 'bold',
+    colors: ['#ff5555', 'yellow', 'lime', 'magenta'],
+    width: '0px',
+    dark: {
+        colors: ['#ff5555', 'yellow', 'lime', 'magenta'],
+        borderColor: '#cccccc',
+        fontWeight: 'bold',
+        width: '0px'
+    },
+    light: {
+        colors: ['#ff5555', '#323D00', '#190096', '#750042'],
+        borderColor: '#cccccc',
+        fontWeight: 'bold',
+        width: '0px'
+    }
+};
+
 export class Configuration
 {
     constructor(unfocused: vscode.TextEditorDecorationType, decoration: vscode.TextEditorDecorationType, allowJumpToWordlessLine: boolean)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
-import processCommand, { ActiveCommandContext, Configuration, SearchMode } from './command';
+import processCommand, { ActiveCommandContext, Configuration, DEFAULT_STYLES, SearchMode, StylesConfiguration } from './command';
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -26,7 +26,8 @@ export function activate(context: vscode.ExtensionContext)
     (
         unfocusedTextDecoration,
         textDecoration,
-        vsConfigOptions.get<boolean>('allowJumpingToWordlessLines', true)
+        vsConfigOptions.get<boolean>('allowJumpingToWordlessLines', true),
+        vsConfigOptions.get<StylesConfiguration>('styles', DEFAULT_STYLES)
     );
     
     let commandContext : ActiveCommandContext | null = null;


### PR DESCRIPTION
Closes #5 

Added zero tests. But local manual testing made it seem alright.

Lemme know what you think of the approach, the documentation and stuff exposed via the manifest etc and my whitespace, of course. 

I also created some defaults for light themes, based on feedback from [coolors's contrast checker](https://coolors.co/contrast-checker) and my own theme, but it's just a start of course.

---

Been a minute since I'd written any J/TS! Forgot all of my clever TS tricks alas haha.