### PR TITLE
Feat: Detect non-english alphanumeric characters

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -29,17 +29,20 @@ function isCharNumber(c: number)
 
 function isCharUpperAlpha(c: number)
 {
-    return c >= 65 && c <= 90;
+    const ch = String.fromCodePoint(c);
+    return isCharAlpha(c) && ch === ch.toUpperCase();
 }
 
 function isCharLowerAlpha(c: number)
 {
-    return c >= 97 && c <= 122;
+    const ch = String.fromCodePoint(c);
+    return isCharAlpha(c) && ch === ch.toLowerCase();
 }
 
 function isCharAlpha(c: number)
 {
-    return isCharUpperAlpha(c) || isCharLowerAlpha(c);
+    const ch = String.fromCodePoint(c);
+    return /^\p{Script=Latin}$/u.test(ch) && /^\p{Letter}$/u.test(ch);
 }
 
 function isCharUnderscore(c: number)

--- a/src/command.ts
+++ b/src/command.ts
@@ -42,7 +42,7 @@ function isCharLowerAlpha(c: number)
 function isCharAlpha(c: number)
 {
     const ch = String.fromCodePoint(c);
-    return /^\p{Script=Latin}$/u.test(ch) && /^\p{Letter}$/u.test(ch);
+    return ch.toLowerCase() !== ch.toUpperCase();
 }
 
 function isCharUnderscore(c: number)


### PR DESCRIPTION
Makes matching non english latin characters possible.

There probably needs to be some tests to verify the correctness of this, but it seems to work pretty flawlessly.

Also saw no big changes in performance, was always below 1ms for 600 matches which I believe should be fast enough.